### PR TITLE
Trivial change to safely check for a string log message.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function mongodbAppender (config) {
 
     return function (loggingEvent) {
         // get the information to log
-        if (typeof loggingEvent.data[0] === 'string') {
+        if(Object.prototype.toString.call(loggingEvent.data[0]) === '[object String]') {
             // format string with layout
             loggingEvent.data = layout(loggingEvent);
         } else if (loggingEvent.data.length === 1) {


### PR DESCRIPTION
typeof `loggingEvent.data[0] === 'string'` will fail if loggingEvent.data[0] was created via `new String("some logging here");` My evidence:

```
node
> var s = "this is a string"; typeof s;
'string'
> var s = new String('this is a string'); typeof s;
'object'
> var s = "this is a string"; Object.prototype.toString.call(s) === '[object String]';
true
> var s = new String('this is a string'); Object.prototype.toString.call(s) === '[object String]';
true
```

Yes, this is truly a trivial change :) At any rate, here's my fix.
