### PR TITLE
added connectionOptions property to configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ logger.info({id: 1, name: 'wayne'});
 ### Configuration
 There are some options which can by set through the config object.
 
+#### connectionOptions
+The connectionOptions object to pass to the mongo db client.
+
+* | *
+--- | ---
+Type | `object`
+Required | `false`
+Default value | `{}`
+
+```js
+var log4js = require('log4js'),
+    mongoAppender = require('log4js-node-mongodb');
+
+log4js.addAppender(
+    mongoAppender.appender({connectionString: 'localhost:27017/logs',
+                            connectionOptions : {server: {ssl: false, sslValidate: false}}}),
+    'cheese'
+);
+```
+
 #### connectionString
 The connection-string to the mongo db.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ function mongodbAppender(config) {
     var cache = [];
     var layout = config.layout || log4js.layouts.messagePassThroughLayout;
     var collectionName = config.collectionName || 'log';
+    var connectionOptions = config.connectionOptions || {};
     var options = { w: 0 };
 
     function ERROR(err) {
@@ -117,7 +118,7 @@ function mongodbAppender(config) {
     }
 
     // connect to mongodb
-    mongodb.MongoClient.connect(config.connectionString, function (err, db) {
+    mongodb.MongoClient.connect(config.connectionString, connectionOptions, function (err, db) {
         if (err) {
             console.error('Error connecting to mongodb! URL: %s', config.connectionString);
             console.error(err);

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -128,6 +128,23 @@ describe('log4js-node-mongoappender', function () {
             });
         }, 100);
     });
+    
+    it('should log to the mongo database given connection options', function (done) {
+      log4js.addAppender(sut.configure({ connectionString: 'localhost:27017/test_log4js_mongo', connectionOptions: {server: {ssl: false, sslValidate: false}} }));
+      log4js.getLogger().info('Ready to log!');
+    
+      setTimeout(function () {
+          db.collection('log').find({}).toArray(function (err, res) {
+              expect(err).toBeNull();
+              expect(res.length).toBe(1);
+              expect(res[0].category).toBe('[default]');
+              expect(res[0].data).toBe('Ready to log!');
+              expect(res[0].level).toEqual({ level: 20000, levelStr: 'INFO' });
+    
+              done();
+          });
+      }, 100);
+    });
 
     it('should log to the mongo database with category [default]', function (done) {
         log4js.addAppender(sut.appender({ connectionString: 'localhost:27017/test_log4js_mongo' }));


### PR DESCRIPTION
While using log4js-node-mongodb for a project, I found that I needed the flexibility of passing in MongoClient specific connection options, so this is my implementation of that.